### PR TITLE
Lock Ruby and Bundler versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.x"
+          ruby-version: "3.1.2"
 
       - name: Install bundler
-        run: gem install bundler
+        run: gem install bundler -v 2.3.15
 
       - name: Setup bundler environment
         run: bundle install

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,9 +1,3 @@
-FROM ruby:3.0.0
+FROM gitpod/workspace-full:latest
 
-# throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
-
-WORKDIR /usr/src/app
-
-ADD Gemfile Gemfile.lock ./
-RUN bundle install
+RUN /bin/bash -l -c ". $HOME/.rvm/scripts/rvm && rvm install 3.1.2 && rvm use 3.1.2 && gem install bundler -v 2.3.15 && bundle config --global frozen 1"


### PR DESCRIPTION
Lock Ruby and Bundler versions. Use the Gitpod workspace full image as there's really no need to try to create a minimal image and the additional tools provided by workspace full (such as Docker) are nice to have when debugging.